### PR TITLE
Force loading of defaults.json

### DIFF
--- a/blockstrap/js/blockstrap.js
+++ b/blockstrap/js/blockstrap.js
@@ -1608,6 +1608,7 @@ var blockstrap_core = function()
             $.ajax({
                 url: 'defaults.json',
                 dataType: 'json',
+                cache: false,
                 success: function(defaults)
                 {
                     // CONSTRUCT PLUGIN AFTER


### PR DESCRIPTION
A lot of times the browser seems to cache defaults.json and does not even go check the server if the file is changes. So the only way to solve this is to force non caching of the file.